### PR TITLE
Update url links and remove features to rhai.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,10 +2,11 @@
 name = "rhai-sci"
 version = "0.1.6"
 edition = "2021"
+resolver = "2"
 authors = ["Chris McComb <ccmcc2012@gmail.com>"]
 description = "Scientific computing in the Rhai scripting language"
-repository = "https://github.com/cmccomb/rhai-sci"
-homepage = "https://github.com/cmccomb/rhai-sci"
+repository = "https://github.com/rhaiscript/rhai-sci"
+homepage = "https://github.com/rhaiscript/rhai-sci"
 readme = "README.md"
 license = "MIT OR Apache-2.0"
 keywords = ["scripting", "rhai", "scientific", "scripting-language", "matlab"]
@@ -14,7 +15,7 @@ documentation = "https://docs.rs/rhai-sci"
 build = "build.rs"
 
 [dependencies]
-rhai = { version = "1.5", features = ["unchecked", "serde", "metadata"]}
+rhai = { version = "1.5" }
 rhai-rand = "0.1.3"
 rustyline = "10.0.0"
 nalgebra = "0.30.1"


### PR DESCRIPTION
It may not be a good idea to pull in features for `rhai`, since cargo will merge these features to the user's.

`metadata` and `serde` are harmless, but will bloat the user's build.  `unchecked`, however, will turn off the user's error checking, which may not be what he wants.

I am not sure if there is any solid dependency on any rhai feature.  It seems that `unchecked` is not really needed, but `metadata` and `serde` are needed only to run doc-tests.

Nevertheless, if you move the functions into Rust, I suppose most of the dependencies will go away since the custom build step won't be necessary.
