### PR TITLE
Add metadata feature.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,8 +4,8 @@ version = "0.1.6"
 edition = "2021"
 authors = ["Chris McComb <ccmcc2012@gmail.com>"]
 description = "Scientific computing in the Rhai scripting language"
-repository = "https://github.com/cmccomb/rhai-sci"
-homepage = "https://github.com/cmccomb/rhai-sci"
+repository = "https://github.com/rhaiscript/rhai-sci"
+homepage = "https://github.com/rhaiscript/rhai-sci"
 readme = "README.md"
 license = "MIT OR Apache-2.0"
 keywords = ["scripting", "rhai", "scientific", "scripting-language", "matlab"]
@@ -13,28 +13,34 @@ categories = ["algorithms", "science"]
 documentation = "https://docs.rs/rhai-sci"
 build = "build.rs"
 
+[features]
+metadata = ["rhai/metadata"]
+
 [dependencies]
-rhai = { version = "1.8", features = ["metadata"]}
+rhai = "1.8"
 rustyline = "10.0.0"
 nalgebra = "0.30.1"
-polars = {version = "0.17.0"}
-url = {version = "2.2.2"}
-temp-file = {version = "0.1.6"}
-csv-sniffer = { version = "0.1.1" }
-minreq = {version = "2.6.0", features = ["json-using-serde", "https"]}
-rand = { version = "0.8" }
+polars = "0.17.0"
+url = "2.2.2"
+temp-file = "0.1.6"
+csv-sniffer = "0.1.1"
+minreq = { version = "2.6.0", features = ["json-using-serde", "https"] }
+rand = "0.8"
 smartstring = "1.0.1"
 
 [build-dependencies]
-rhai = { version = "1.8", features = ["metadata"]}
+rhai = "1.8"
 itertools = "0.10.3"
 nalgebra = "0.30.1"
-polars = {version = "0.17.0"}
-url = {version = "2.2.2"}
-temp-file = {version = "0.1.6"}
-csv-sniffer = { version = "0.1.1" }
-minreq = {version = "2.6.0", features = ["json-using-serde", "https"]}
-rand = { version = "0.8" }
+polars = "0.17.0"
+url = "2.2.2"
+temp-file = "0.1.6"
+csv-sniffer = "0.1.1"
+minreq = { version = "2.6.0", features = ["json-using-serde", "https"] }
+rand = "0.8"
 serde_json = "1.0.82"
 serde = "1.0.140"
 smartstring = "1.0.1"
+
+[package.metadata.docs.rs]
+features = ["metadata"]

--- a/build.rs
+++ b/build.rs
@@ -1,10 +1,36 @@
-use itertools::Itertools;
-use rhai::{packages::Package, plugin::*, Engine, ScriptFnMetadata};
-use serde_json::Value;
-use std::collections::HashMap;
-use std::io::Write;
-
+#[cfg(not(feature = "metadata"))]
 fn main() {
+    // Update if needed
+    println!("cargo:rerun-if-changed=src");
+    println!("cargo:rerun-if-changed=build.rs");
+
+    // Make empty file for documentation
+    std::fs::File::create(std::env::var("OUT_DIR").unwrap() + "/rhai-sci-docs.md").unwrap();
+}
+
+#[cfg(feature = "metadata")]
+fn main() {
+    use itertools::Itertools;
+    use rhai::{packages::Package, plugin::*, Engine, ScriptFnMetadata};
+    use serde::{Deserialize, Serialize};
+    use serde_json::Value;
+    use std::collections::HashMap;
+    use std::io::Write;
+
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    struct Function {
+        pub access: String,
+        pub baseHash: u128,
+        pub fullHash: u128,
+        pub name: String,
+        pub namespace: String,
+        pub numParams: usize,
+        pub params: Option<Vec<HashMap<String, String>>>,
+        pub signature: String,
+        pub returnType: Option<String>,
+        pub docComments: Option<Vec<String>>,
+    }
+
     // Update if needed
     println!("cargo:rerun-if-changed=src");
     println!("cargo:rerun-if-changed=build.rs");
@@ -41,7 +67,7 @@ fn main() {
     let function_list = v["functions"].clone();
 
     // Write functions
-    write!(doc_file, "# Functions\n This package provides a large variety of functions to help with scientific computing. Each one of these is written in Rhai itself! The source code is here.\n").expect("Cannot write to {test_file}");
+    write!(doc_file, "# Functions\n This package provides a large variety of functions to help with scientific computing.\n").expect("Cannot write to {test_file}");
     let mut indented = false;
     for (idx, function) in function_list.iter().enumerate() {
         let mut function = function.clone();
@@ -104,29 +130,20 @@ fn main() {
         }
     }
 }
-use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
-struct Function {
-    pub access: String,
-    pub baseHash: u128,
-    pub fullHash: u128,
-    pub name: String,
-    pub namespace: String,
-    pub numParams: usize,
-    pub params: Option<Vec<HashMap<String, String>>>,
-    pub signature: String,
-    pub returnType: Option<String>,
-    pub docComments: Option<Vec<String>>,
+#[cfg(feature = "metadata")]
+mod functions {
+    include!("src/matrices_and_arrays.rs");
+    include!("src/statistics.rs");
+    include!("src/misc.rs");
+    include!("src/cumulative.rs");
+    include!("src/integration_and_differentiation.rs");
+    include!("src/assertions.rs");
+    include!("src/constants.rs");
+    include!("src/sets.rs");
+    include!("src/moving.rs");
+    include!("src/validate.rs");
 }
 
-include!("src/matrices_and_arrays.rs");
-include!("src/statistics.rs");
-include!("src/misc.rs");
-include!("src/cumulative.rs");
-include!("src/integration_and_differentiation.rs");
-include!("src/assertions.rs");
-include!("src/constants.rs");
-include!("src/sets.rs");
-include!("src/moving.rs");
-include!("src/validate.rs");
+#[cfg(feature = "metadata")]
+pub use functions::*;


### PR DESCRIPTION
For some reason, using `resolver = "2"` doesn't work, probably due to the sub-dependency on `rhai_codegen`.  Which is a pity.

However, it is standard to have a `metadata` feature on packages to turn on/off docs.